### PR TITLE
Simplyfy the code regarding high/low Zpt variables 

### DIFF
--- a/CommonSelectors.py
+++ b/CommonSelectors.py
@@ -152,11 +152,7 @@ def DiJetMassCut(events, params, **kwargs):
 
 
 def DiLeptonPtCut(events, params, **kwargs):
-
-    if params["high"]:
-        mask = (  (events.ll.pt > params["ptll"]["low"]))      
-    else:
-        mask = (  (events.ll.pt > params["ptll"]["low"]) & (events.ll.pt < params["ptll"]["high"]) )
+    mask = (  (events.ll.pt > params["ptll"]["low"]) & (events.ll.pt < params["ptll"]["high"]) )
     return ak.where(ak.is_none(mask), False, mask)
 
 
@@ -358,21 +354,19 @@ Zll_2j = Cut(
 )
 
 
-Zll_2j_low = Cut(
-    name="Zll_2j_low",
+dilep_pt60to150 = Cut(
+    name="dilep_pt60to150",
     function=DiLeptonPtCut,
     params={
-        "high": False,
-	"ptll": {'low': 50, 'high': 150}
+	"ptll": {'low': 60, 'high': 150}
     },
 )
 
-Zll_2j_high = Cut(
-    name="Zll_2j_high",
+dilep_pt150to2000 = Cut(
+    name="dilep_pt150to2000",
     function=DiLeptonPtCut,
     params={
-        "high": True,
-	"ptll": {'low': 150}
+	"ptll": {'low': 150, 'high': 2000}
     },
 )
 

--- a/cfg_VHcc_ZLL.py
+++ b/cfg_VHcc_ZLL.py
@@ -41,13 +41,14 @@ files_2018 = [
     f"{localdir}/datasets/Run2UL2018_MC_OtherBkg.json",
     f"{localdir}/datasets/Run2UL2018_DATA.json",
 ]
-#files_Run3 = [
-#    f"{localdir}/datasets/Run3_MC_VJets.json",
-#    f"{localdir}/datasets/Run3_MC_OtherBkg.json",
-#    f"{localdir}/datasets/Run3_DATA.json",
-#]
+files_Run3 = [
+    f"{localdir}/datasets/Run3_MC_VJets.json",
+    f"{localdir}/datasets/Run3_MC_OtherBkg.json",
+    f"{localdir}/datasets/Run3_DATA.json",
+]
 
 parameters["proc_type"] = "ZLL"
+parameters["save_arrays"] = False
 
 cfg = Configurator(
     parameters = parameters,
@@ -111,7 +112,7 @@ cfg = Configurator(
         "common": {
             "inclusive": ["signOf_genWeight","lumi","XS",
                           "pileup", #Not in 2022/2023
-                          #"sf_mu_id","sf_mu_iso",
+                          "sf_mu_id","sf_mu_iso",
                           "sf_ele_reco","sf_ele_id",
                           #"sf_ctag", "sf_ctag_calib"
                           ],
@@ -128,7 +129,7 @@ cfg = Configurator(
             "common": {
                 "inclusive": [
                     "pileup",
-                    #"sf_mu_id", "sf_mu_iso",
+                    "sf_mu_id", "sf_mu_iso",
                     "sf_ele_reco", "sf_ele_id",
                     #"sf_ctag",
                 ]
@@ -157,43 +158,44 @@ cfg = Configurator(
 	**jet_hists(coll="JetsCvsL", pos=1),
 
         "nJet": HistConf( [Axis(field="nJet", bins=15, start=0, stop=15, label=r"nJet direct from NanoAOD")] ),
-        "dilepton_m": HistConf( [Axis(field="dilep_mass", bins=100, start=0, stop=200, label=r"$M_{\ell\ell}$ [GeV]")] ),
-        "dilepton_pt": HistConf( [Axis(field="dilep_pt", bins=100, start=0, stop=200, label=r"$p_{T_{\ell\ell}}$ [GeV]")] ),
-        "dilepton_dphi": HistConf( [Axis(field="dilep_phi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{\ell\ell}$")] ),
-        "dilepton_deta": HistConf( [Axis(field="dilep_eta", bins=100, start=-1, stop=4, label=r"$\Delta \eta_{\ell\ell}$")] ),
-        "dilepton_dijet_ratio": HistConf( [Axis(field="pt_ratio", bins=100, start=0, stop=2, label=r"$\frac{p_T(\ell\ell)}{p_T(jj)}$")] ),
-        "dilepton_dijet_dphi": HistConf( [Axis(field="ZH_delphi", bins=100, start=-4, stop=4, label=r"$\Delta \phi (\ell\ell, jj)$")] ),
-        "dilepton_l2j1": HistConf( [Axis(field="deltaPhi_l2_j1", bins=100, start=-1, stop=3.5, label=r"$\Delta \phi (\ell_2, j_1)$")] ),
-        "dilepton_l2j2": HistConf( [Axis(field="deltaPhi_l2_j2", bins=100, start=-1, stop=3.5, label=r"$\Delta \phi (\ell_2, j_2)$")] ),
         
         "dilep_m" : HistConf( [Axis(coll="ll", field="mass", bins=100, start=0, stop=200, label=r"$M_{\ell\ell}$ [GeV]")] ),
         "dilep_m_zoom" : HistConf( [Axis(coll="ll", field="mass", bins=40, start=70, stop=110, label=r"$M_{\ell\ell}$ [GeV]")] ),
-        "dilep_dr" : HistConf( [Axis(coll="ll", field="deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{\ell\ell}$")] ),
         "dilep_pt" : HistConf( [Axis(coll="ll", field="pt", bins=100, start=0, stop=400, label=r"$p_T{\ell\ell}$ [GeV]")] ),
+        "dilep_deltaR" : HistConf( [Axis(coll="ll", field="deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{\ell\ell}$")] ),
+        
+        "dilep_deltaPhi": HistConf( [Axis(field="dilep_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{\ell\ell}$")] ),
+        "dilep_deltaEta": HistConf( [Axis(field="dilep_deltaEta", bins=100, start=-1, stop=4, label=r"$\Delta \eta_{\ell\ell}$")] ),
+
+        "dilep_dijet_ratio": HistConf( [Axis(field="ZH_pt_ratio", bins=100, start=0, stop=2, label=r"$\frac{p_T(\ell\ell)}{p_T(jj)}$")] ),
+        "dilep_dijet_dphi": HistConf( [Axis(field="ZH_deltaPhi", bins=100, start=-4, stop=4, label=r"$\Delta \phi (\ell\ell, jj)$")] ),
+        "dilep_l2j1": HistConf( [Axis(field="deltaPhi_l2_j1", bins=100, start=-1, stop=3.5, label=r"$\Delta \phi (\ell_2, j_1)$")] ),
+        "dilep_l2j2": HistConf( [Axis(field="deltaPhi_l2_j2", bins=100, start=-1, stop=3.5, label=r"$\Delta \phi (\ell_2, j_2)$")] ),
 
         "dijet_m" : HistConf( [Axis(field="dijet_m", bins=100, start=0, stop=600, label=r"$M_{jj}$ [GeV]")] ),
-        "dijet_dr" : HistConf( [Axis(field="dijet_deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$")] ),
-        "dijet_dphi": HistConf( [Axis(field="dijet_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{jj}$")] ),
-        "dijet_deta": HistConf( [Axis(field="dijet_deltaEta", bins=100, start=-1, stop=4, label=r"$\Delta \eta_{jj}$")] ),
         "dijet_pt" : HistConf( [Axis(field="dijet_pt", bins=100, start=0, stop=400, label=r"$p_T{jj}$ [GeV]")] ),
+        "dijet_deltaR" : HistConf( [Axis(field="dijet_deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$")] ),
+        "dijet_deltaPhi": HistConf( [Axis(field="dijet_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{jj}$")] ),
+        "dijet_deltaEta": HistConf( [Axis(field="dijet_deltaEta", bins=100, start=-1, stop=4, label=r"$\Delta \eta_{jj}$")] ),
         
         "dijet_csort_m" : HistConf( [Axis(coll="dijet_csort", field="mass", bins=100, start=0, stop=600, label=r"$M_{jj}$ [GeV]")] ),
-        "dijet_csort_dr" : HistConf( [Axis(coll="dijet_csort", field="deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$")] ),
         "dijet_csort_pt" : HistConf( [Axis(coll="dijet_csort", field="pt", bins=100, start=0, stop=400, label=r"$p_T{jj}$ [GeV]")] ),
+        "dijet_csort_dr" : HistConf( [Axis(coll="dijet_csort", field="deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$")] ),
 
 
         "HT":  HistConf( [Axis(field="JetGood_Ht", bins=100, start=0, stop=700, label=r"Jet HT [GeV]")] ),
         "met_pt": HistConf( [Axis(coll="MET", field="pt", bins=50, start=0, stop=200, label=r"MET $p_T$ [GeV]")] ),
         "met_phi": HistConf( [Axis(coll="MET", field="phi", bins=64, start=-math.pi, stop=math.pi, label=r"MET $phi$")] ),
 
-        # 2D plots
+        # 2D histograms:
         "Njet_Ht": HistConf([ Axis(coll="events", field="nJetGood",bins=[0,2,3,4,8],
                                    type="variable",   label="N. Jets (good)"),
                               Axis(coll="events", field="JetGood_Ht",
                                    bins=[0,80,150,200,300,450,700],
                                    type="variable",
                                    label="Jets $H_T$ [GeV]")]),
-        "dphi_jj_dr_jj": HistConf([ Axis(field="dijet_deltaR_low", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$, 50 < $p_{T_{\ell\ell}}$ < 150"),
-                              Axis(field="dijet_deltaPhi_low", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{jj}$, 50 < $p_{T_{\ell\ell}}$ < 150")]),
+        
+        "dphi_jj_dr_jj": HistConf([ Axis(field="dijet_deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$"),
+                                    Axis(field="dijet_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{jj}$")]),
     }
 )

--- a/cfg_VHcc_ZLL.py
+++ b/cfg_VHcc_ZLL.py
@@ -62,8 +62,8 @@ cfg = Configurator(
                 "DATA_EGamma",   # in 2018/2022/2023
                 ##"DATA_SingleMuon",
                 ##"DATA_SingleElectron",
-	        "WW", "WZ", "ZZ",
-                "DYJetsToLL_FxFx",
+	        #"WW", "WZ", "ZZ",
+                #"DYJetsToLL_FxFx",
                 "DYJetsToLL_MLM",
                 #"TTToSemiLeptonic",
                 #"DYJetsToLL_MiNNLO",
@@ -74,11 +74,8 @@ cfg = Configurator(
             #"year": ['2017']
             #"year": ['2016_PreVFP', '2016_PostVFP','2017','2018']
             #"year": ['2022_preEE','2022_postEE','2023_preBPix','2023_postBPix']
-
             #"year": ['2022_preEE','2022_postEE']
-
-            "year": ['2022_preEE','2022_postEE']
-
+            "year": ['2023_preBPix', '2023_postBPix']
         }
     },
 
@@ -133,12 +130,17 @@ cfg = Configurator(
                     "pileup",
                     #"sf_mu_id", "sf_mu_iso",
                     "sf_ele_reco", "sf_ele_id",
-                    #"sf_ctag"
+                    #"sf_ctag",
                 ]
             },
-            "bysample": {
-            }
+            "bysample": { }
         },
+        "shape": {
+            "common":{
+                #"inclusive": [ "JES_Total_AK4PFchs", "JER_AK4PFchs" ] # For Run2UL
+                "inclusive": [ "JES_Total_AK4PFPuppi", "JER_AK4PFPuppi" ] # For Run3
+            }
+        }
     },
 
     variables = {

--- a/cfg_VHcc_ZLL.py
+++ b/cfg_VHcc_ZLL.py
@@ -98,8 +98,8 @@ cfg = Configurator(
         "SR_ee_2J_cJ": [Zee_2j, ctag_j1, dijet_mass_cut],
         "SR_ll_2J_cJ": [Zll_2j, ctag_j1, dijet_mass_cut],
 
-        "SR_ll_2j_low": [Zll_2j, dijet_mass_cut, Zll_2j_low],
-        "SR_ll_2j_high": [Zll_2j, dijet_mass_cut, Zll_2j_high],
+        "SR_ll_2J_cJ_low":  [Zll_2j, dijet_mass_cut, dilep_pt60to150],
+        "SR_ll_2J_cJ_high": [Zll_2j, dijet_mass_cut, dilep_pt150to2000],
 
         
         "CR_ll_2J_LF": [Zll_2j, antictag_j1, dijet_mass_cut],
@@ -162,8 +162,7 @@ cfg = Configurator(
         "dilep_m" : HistConf( [Axis(coll="ll", field="mass", bins=100, start=0, stop=200, label=r"$M_{\ell\ell}$ [GeV]")] ),
         "dilep_m_zoom" : HistConf( [Axis(coll="ll", field="mass", bins=40, start=70, stop=110, label=r"$M_{\ell\ell}$ [GeV]")] ),
         "dilep_pt" : HistConf( [Axis(coll="ll", field="pt", bins=100, start=0, stop=400, label=r"$p_T{\ell\ell}$ [GeV]")] ),
-        "dilep_deltaR" : HistConf( [Axis(coll="ll", field="deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{\ell\ell}$")] ),
-        
+        "dilep_dr" : HistConf( [Axis(coll="ll", field="deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{\ell\ell}$")] ),
         "dilep_deltaPhi": HistConf( [Axis(field="dilep_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{\ell\ell}$")] ),
         "dilep_deltaEta": HistConf( [Axis(field="dilep_deltaEta", bins=100, start=-1, stop=4, label=r"$\Delta \eta_{\ell\ell}$")] ),
 
@@ -174,7 +173,7 @@ cfg = Configurator(
 
         "dijet_m" : HistConf( [Axis(field="dijet_m", bins=100, start=0, stop=600, label=r"$M_{jj}$ [GeV]")] ),
         "dijet_pt" : HistConf( [Axis(field="dijet_pt", bins=100, start=0, stop=400, label=r"$p_T{jj}$ [GeV]")] ),
-        "dijet_deltaR" : HistConf( [Axis(field="dijet_deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$")] ),
+        "dijet_dr" : HistConf( [Axis(field="dijet_dr", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$")] ),
         "dijet_deltaPhi": HistConf( [Axis(field="dijet_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{jj}$")] ),
         "dijet_deltaEta": HistConf( [Axis(field="dijet_deltaEta", bins=100, start=-1, stop=4, label=r"$\Delta \eta_{jj}$")] ),
         
@@ -195,7 +194,7 @@ cfg = Configurator(
                                    type="variable",
                                    label="Jets $H_T$ [GeV]")]),
         
-        "dphi_jj_dr_jj": HistConf([ Axis(field="dijet_deltaR", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$"),
+        "dphi_jj_dr_jj": HistConf([ Axis(field="dijet_dr", bins=50, start=0, stop=5, label=r"$\Delta R_{jj}$"),
                                     Axis(field="dijet_deltaPhi", bins=64, start=-1, stop=3.5, label=r"$\Delta \phi_{jj}$")]),
     }
 )

--- a/workflow.py
+++ b/workflow.py
@@ -88,13 +88,13 @@ class VHccBaseProcessor(BaseProcessorABC):
             ### General
             self.events["dijet_m"] = self.events.dijet.mass
             self.events["dijet_pt"] = self.events.dijet.pt
-            self.events["dijet_deltaR"] = self.events.dijet.deltaR
+            self.events["dijet_dr"] = self.events.dijet.deltaR
             self.events["dijet_deltaPhi"] = self.events.dijet.deltaPhi
             self.events["dijet_deltaEta"] = self.events.dijet.deltaEta
 
             self.events["dilep_m"] = self.events.ll.mass
             self.events["dilep_pt"] = self.events.ll.pt
-            self.events["dilep_deltaR"] = self.events.ll.deltaR
+            self.events["dilep_dr"] = self.events.ll.deltaR
             self.events["dilep_deltaPhi"] = self.events.ll.deltaPhi
             self.events["dilep_deltaEta"] = self.events.ll.deltaEta
             
@@ -114,13 +114,13 @@ class VHccBaseProcessor(BaseProcessorABC):
                 variables_to_save = ak.zip({
                     "dilep_m": self.events["dilep_m"],
                     "dilep_pt": self.events["dilep_pt"],
-                    "dilep_deltaR": self.events["dilep_deltaR"],
+                    "dilep_dr": self.events["dilep_deltaR"],
                     "dilep_deltaPhi": self.events["dilep_deltaPhi"],
                     "dilep_deltaEta": self.events["dilep_deltaEta"],
                     
                     "dijet_m": self.events["dijet_m"],
                     "dijet_pt": self.events["dijet_pt"],
-                    "dijet_deltaR": self.events["dijet_deltaR"],
+                    "dijet_dr": self.events["dijet_deltaR"],
                     "dijet_deltaPhi": self.events["dijet_deltaPhi"],
                     "dijet_deltaEta": self.events["dijet_deltaEta"],
                     

--- a/workflow.py
+++ b/workflow.py
@@ -5,7 +5,6 @@ import pandas as pd
 import warnings
 import os
 
-
 from pocket_coffea.workflows.base import BaseProcessorABC
 from pocket_coffea.utils.configurator import Configurator
 from pocket_coffea.lib.hist_manager import Axis
@@ -19,15 +18,19 @@ from pocket_coffea.lib.objects import (
     get_dijet
 )
 
+def delta_phi(a, b):
+    """Compute difference in angle between two vectors    
+    Returns a value within [-pi, pi)
+    """
+    return (a - b + np.pi) % (2 * np.pi) - np.pi
 
 class VHccBaseProcessor(BaseProcessorABC):
     def __init__(self, cfg: Configurator):
         super().__init__(cfg)
 
-        self.proc_type = self.params["proc_type"]
-        
-        #self.isRun3 = True if self.params["run_period"]=='Run3' else False
-        
+        self.proc_type   = self.params["proc_type"]
+        self.save_arrays = self.params["save_arrays"]
+                
     def apply_object_preselection(self, variation):
         '''
         
@@ -77,134 +80,56 @@ class VHccBaseProcessor(BaseProcessorABC):
 
     def define_common_variables_after_presel(self, variation):
         self.events["dijet"] = get_dijet(self.events.JetGood)
-        
-        
-        
+                
         #self.events["dijet_pt"] = self.events.dijet.pt
         
         if self.proc_type=="ZLL":
-            high_pt_mask = (self.events.ll.pt > 150)
-            low_pt_mask = (self.events.ll.pt >= 50) & (self.events.ll.pt < 150)
-            
-            # Determine the maximum length
-            max_length = len(self.events.ll)
-            ll_low = self.events.ll[low_pt_mask]
-            ll_high = self.events.ll[high_pt_mask]
-            dijet_low = self.events.dijet[low_pt_mask]
-            dijet_high = self.events.dijet[high_pt_mask]
-            # Pad the arrays to match the maximum length
-            ll_low_padded = ak.pad_none(ll_low, max_length, axis=0)
-            ll_high_padded = ak.pad_none(ll_high, max_length, axis=0)
-            dijet_low_padded = ak.pad_none(dijet_low, max_length, axis=0)
-            dijet_high_padded = ak.pad_none(dijet_high, max_length, axis=0)
 
-            # Concatenate the jagged arrays along the first axis
-            self.events["ll_low"] = ll_low_padded
-            self.events["ll_high"] = ll_high_padded
-            self.events["dijet_low"] = dijet_low_padded
-            self.events["dijet_high"] = dijet_high_padded
-            
             ### General
+            self.events["dijet_m"] = self.events.dijet.mass
+            self.events["dijet_pt"] = self.events.dijet.pt
             self.events["dijet_deltaR"] = self.events.dijet.deltaR
             self.events["dijet_deltaPhi"] = self.events.dijet.deltaPhi
             self.events["dijet_deltaEta"] = self.events.dijet.deltaEta
-            self.events["dijet_m"] = self.events.dijet.mass
-            self.events["dijet_pt"] = self.events.dijet.pt
-            self.events["dilep_deltaR"] = self.events.ll.deltaR
+
+            self.events["dilep_m"] = self.events.ll.mass
             self.events["dilep_pt"] = self.events.ll.pt
-            self.events["dilep_mass"] = self.events.ll.mass
-            self.events["dilep_phi"] = self.events.ll.deltaPhi
-            self.events["dilep_eta"] = self.events.ll.deltaEta
-            self.events["pt_ratio"] = self.events.ll.pt/self.events.dijet.pt
-            self.events["ZH_delphi"] = np.abs(self.events.ll.delta_phi(self.events.dijet))
+            self.events["dilep_deltaR"] = self.events.ll.deltaR
+            self.events["dilep_deltaPhi"] = self.events.ll.deltaPhi
+            self.events["dilep_deltaEta"] = self.events.ll.deltaEta
+            
+            self.events["ZH_pt_ratio"] = self.events.ll.pt/self.events.dijet.pt
+            self.events["ZH_deltaPhi"] = np.abs(self.events.ll.delta_phi(self.events.dijet))
+
+            # why cant't we use delta_phi function here?
             self.angle21_gen = (abs(self.events.ll.l2phi - self.events.dijet.j1Phi) < np.pi)
             self.angle22_gen = (abs(self.events.ll.l2phi - self.events.dijet.j2Phi) < np.pi)
             self.events["deltaPhi_l2_j1"] = ak.where(self.angle21_gen, abs(self.events.ll.l2phi - self.events.dijet.j1Phi), 2*np.pi - abs(self.events.ll.l2phi - self.events.dijet.j1Phi))              
             self.events["deltaPhi_l2_j2"] = ak.where(self.angle22_gen, abs(self.events.ll.l2phi - self.events.dijet.j2Phi), 2*np.pi - abs(self.events.ll.l2phi - self.events.dijet.j2Phi))
-            
-            
-            ### Low_pt dilepton
-            self.events["dijet_deltaR_low"] = self.events.dijet_low.deltaR
-            self.events["dijet_deltaPhi_low"] = self.events.dijet_low.deltaPhi
-            self.events["dijet_deltaEta_low"] = self.events.dijet_low.deltaEta
-            self.events["dijet_m_low"] = self.events.dijet_low.mass
-            self.events["dijet_pt_low"] = self.events.dijet_low.pt
-            self.events["dilep_deltaR_low"] = self.events.ll_low.deltaR
-            self.events["dilep_pt_low"] = self.events.ll_low.pt
-            self.events["dilep_mass_low"] = self.events.ll_low.mass
-            self.events["dilep_phi_low"] = self.events.ll_low.deltaPhi
-            self.events["dilep_eta_low"] = self.events.ll_low.deltaEta
-            self.events["pt_ratio_low"] = self.events.ll_low.pt/self.events.dijet_low.pt
-            self.events["ZH_delphi_low"] = np.abs(self.events.ll_low.delta_phi(self.events.dijet_low))
-            self.angle21 = (abs(self.events.ll_low.l2phi - self.events.dijet_low.j1Phi) < np.pi)
-            self.angle22 = (abs(self.events.ll_low.l2phi - self.events.dijet_low.j2Phi) < np.pi)
-            self.events["deltaPhi_l2_j1_low"] = ak.where(self.angle21, abs(self.events.ll_low.l2phi - self.events.dijet_low.j1Phi), 2*np.pi - abs(self.events.ll_low.l2phi - self.events.dijet_low.j1Phi))              
-            self.events["deltaPhi_l2_j2_low"] = ak.where(self.angle22, abs(self.events.ll_low.l2phi - self.events.dijet_low.j2Phi), 2*np.pi - abs(self.events.ll_low.l2phi - self.events.dijet_low.j2Phi))
-            
-            ### High_pt dilepton
-            
-            self.events["dijet_deltaR_high"] = self.events.dijet_high.deltaR
-            self.events["dijet_deltaPhi_high"] = self.events.dijet_high.deltaPhi
-            self.events["dijet_deltaEta_high"] = self.events.dijet_high.deltaEta
-            self.events["dijet_m_high"] = self.events.dijet_high.mass
-            self.events["dijet_pt_high"] = self.events.dijet_high.pt
-            self.events["dilep_deltaR_high"] = self.events.ll_high.deltaR
-            self.events["dilep_pt_high"] = self.events.ll_high.pt
-            self.events["dilep_mass_high"] = self.events.ll_high.mass
-            self.events["dilep_phi_high"] = self.events.ll_high.deltaPhi
-            self.events["dilep_eta_high"] = self.events.ll_high.deltaEta
-            self.events["pt_ratio_high"] = self.events.ll_high.pt/self.events.dijet_high.pt
-            self.events["ZH_delphi_high"] = np.abs(self.events.ll_high.delta_phi(self.events.dijet_high))
-            self.angle21_h = (abs(self.events.ll_high.l2phi - self.events.dijet_high.j1Phi) < np.pi)
-            self.angle22_h = (abs(self.events.ll_high.l2phi - self.events.dijet_high.j2Phi) < np.pi)
-            self.events["deltaPhi_l2_j1_high"] = ak.where(self.angle21_h, abs(self.events.ll_high.l2phi - self.events.dijet_high.j1Phi), 2*np.pi - abs(self.events.ll_high.l2phi - self.events.dijet_high.j1Phi))
-            self.events["deltaPhi_l2_j2_high"] = ak.where(self.angle22_h, abs(self.events.ll_high.l2phi - self.events.dijet_high.j2Phi), 2*np.pi - abs(self.events.ll_high.l2phi - self.events.dijet_high.j2Phi))
-            
-            # Create a record for the low_ variables
-            # Create a record for the low_ variables
-            low_variables = ak.zip({
-                "dilep_deltaR": self.events["dilep_deltaR_low"],
-                "dilep_pt": self.events["dilep_pt_low"],
-                "dilep_mass": self.events["dilep_mass_low"],
-                "dilep_phi": self.events["dilep_phi_low"],
-                "dilep_eta": self.events["dilep_eta_low"],
-                "pt_ratio": self.events["pt_ratio_low"],
-                "ZH_delphi": self.events["ZH_delphi_low"],
-                "deltaPhi_l2_j1": self.events["deltaPhi_l2_j1_low"],
-                "deltaPhi_l2_j2": self.events["deltaPhi_l2_j2_low"],
-                "dijet_deltaR": self.events["dijet_deltaR_low"],
-                "dijet_deltaPhi": self.events["dijet_deltaPhi_low"],
-                "dijet_deltaEta": self.events["dijet_deltaEta_low"],
-                "dijet_m": self.events["dijet_m_low"],
-                "dijet_pt": self.events["dijet_pt_low"]
-            })
+            self.events["deltaPhi_l2_j1"] = np.abs(delta_phi(self.events.ll.l2phi, self.events.dijet.j1Phi))
 
-            # Create a record for the high_ variables
-            high_variables = ak.zip({
-                "dilep_deltaR": self.events["dilep_deltaR_high"],
-                "dilep_pt": self.events["dilep_pt_high"],
-                "dilep_mass": self.events["dilep_mass_high"],
-                "dilep_phi": self.events["dilep_phi_high"],
-                "dilep_eta": self.events["dilep_eta_high"],
-                "pt_ratio": self.events["pt_ratio_high"],
-                "ZH_delphi": self.events["ZH_delphi_high"],
-                "deltaPhi_l2_j1": self.events["deltaPhi_l2_j1_high"],
-                "deltaPhi_l2_j2": self.events["deltaPhi_l2_j2_high"],
-                "dijet_deltaR": self.events["dijet_deltaR_high"],
-                "dijet_deltaPhi": self.events["dijet_deltaPhi_high"],
-                "dijet_deltaEta": self.events["dijet_deltaEta_high"],
-                "dijet_m": self.events["dijet_m_high"],
-                "dijet_pt": self.events["dijet_pt_high"]
-            })
-
-
-            # Add the records to the events
-            self.events["low_variables"] = low_variables
-            self.events["high_variables"] = high_variables
-
-        
-        
-
+            
+            if self.save_arrays:
+                # Create a record of variables to be dumped as root/parquete file:
+                variables_to_save = ak.zip({
+                    "dilep_m": self.events["dilep_m"],
+                    "dilep_pt": self.events["dilep_pt"],
+                    "dilep_deltaR": self.events["dilep_deltaR"],
+                    "dilep_deltaPhi": self.events["dilep_deltaPhi"],
+                    "dilep_deltaEta": self.events["dilep_deltaEta"],
+                    
+                    "dijet_m": self.events["dijet_m"],
+                    "dijet_pt": self.events["dijet_pt"],
+                    "dijet_deltaR": self.events["dijet_deltaR"],
+                    "dijet_deltaPhi": self.events["dijet_deltaPhi"],
+                    "dijet_deltaEta": self.events["dijet_deltaEta"],
+                    
+                    "ZH_pt_ratio": self.events["ZH_pt_ratio"],
+                    "ZH_deltaPhi": self.events["ZH_deltaPhi"],
+                    "deltaPhi_l2_j1": self.events["deltaPhi_l2_j1"],
+                    "deltaPhi_l2_j2": self.events["deltaPhi_l2_j2"],
+                })
+                
         if self.proc_type=="ZNuNu":
             self.events["deltaPhi_jet1_MET"] = np.abs(self.events.MET.delta_phi(self.events.JetGood[:,0]))
             self.events["deltaPhi_jet2_MET"] = np.abs(self.events.MET.delta_phi(self.events.JetGood[:,1]))
@@ -218,20 +143,24 @@ class VHccBaseProcessor(BaseProcessorABC):
         #print("CvsL sort CvsL:", self.events["JetsCvsL"][self.events["nJetGood"]>=3].btagDeepFlavCvL)
 
         self.events["dijet_csort"] = get_dijet(self.events.JetsCvsL)
-        
-        # Suppress FutureWarning
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=FutureWarning)
-            
-             # write to root files
-            # Check if the directory exists
-            if not os.path.exists(f"Saved_root_files/{self.events.metadata['dataset']}"):
-                # If not, create it
-                os.system(f"mkdir -p Saved_root_files/{self.events.metadata['dataset']}")
-            # Write the events to a ROOT file
-            # Write the events to a ROOT file
-            with uproot.recreate(f"Saved_root_files/{self.events.metadata['dataset']}/{self.events.metadata['filename'].split('/')[-1].replace('.root','')}_{int(self.events.metadata['entrystart'])}_{int(self.events.metadata['entrystop'])}.root") as f: 
-                f["low_variables"] = ak.to_pandas(low_variables)
-                f["high_variables"] = ak.to_pandas(high_variables) 
-            ak.to_pandas(self.events["low_variables"]).to_parquet(f"Saved_root_files/{self.events.metadata['dataset']}/{self.events.metadata['filename'].split('/')[-1].replace('.root','')}_{int(self.events.metadata['entrystart'])}_{int(self.events.metadata['entrystop'])}_low_vars.parquet")
-            ak.to_pandas(self.events["high_variables"]).to_parquet(f"Saved_root_files/{self.events.metadata['dataset']}/{self.events.metadata['filename'].split('/')[-1].replace('.root','')}_{int(self.events.metadata['entrystart'])}_{int(self.events.metadata['entrystop'])}_high_vars.parquet")  
+
+
+
+        if self.save_arrays:
+            # Here we write to root  and parquete files
+
+            with warnings.catch_warnings():
+                # Suppress FutureWarning
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                
+                # Check if the directory exists
+                if not os.path.exists(f"Saved_root_files/{self.events.metadata['dataset']}"):
+                    # If not, create it
+                    os.system(f"mkdir -p Saved_root_files/{self.events.metadata['dataset']}")
+                    
+                # Write the events to a ROOT file
+                with uproot.recreate(f"Saved_root_files/{self.events.metadata['dataset']}/{self.events.metadata['filename'].split('/')[-1].replace('.root','')}_{int(self.events.metadata['entrystart'])}_{int(self.events.metadata['entrystop'])}.root") as f: 
+                    f["variables"] = ak.to_pandas(variables_to_save)
+
+                # Write the events to a Parquet file
+                ak.to_pandas(ak.to_pandas(variables_to_save)).to_parquet(f"Saved_root_files/{self.events.metadata['dataset']}/{self.events.metadata['filename'].split('/')[-1].replace('.root','')}_{int(self.events.metadata['entrystart'])}_{int(self.events.metadata['entrystop'])}_vars.parquet")


### PR DESCRIPTION
I believe that we do not want to create separate variables for high and low Zpt regions.
The separation for histograms is taken care by categories.

For the arrays as well, we do not need separate variables. The `dilep_pt` is saved and one should use it to split for high and low pt regions afterwards when necessary. In fact, this is better for cut optimization (maybe we could use different pt cuts).

In addition I introduced a boolean in config file `save_arrays` to enable or disable this feature.
This works for me. @ValVau could you please test and let me know if that is OK for you as well.